### PR TITLE
Disable subscription for DoP

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -25,7 +25,7 @@ server:
   apiAuthGoogleClientId:
   apiAuthGoogleClientSecret:
   clusterDomain: cluster.local
-  featureSubscriptionDisable: false
+  featureSubscriptionDisable: true
   subscriptionType: internal
   featureBillingDisable: true
   billingType: external


### PR DESCRIPTION
Subscription is a DoL specific feature and it shouldn't be enabled on DoP