### PR TITLE
custom registry for openebs

### DIFF
--- a/templates/openebs/_helpers.tpl
+++ b/templates/openebs/_helpers.tpl
@@ -41,3 +41,41 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+{{/*
+Custom docker repositry to use in image.
+*/}}
+{{- define "ndmImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "node-disk-manager-amd64" .Values.ndm.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "admission-webhookImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "admission-server" .Values.webhook.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "localprovisionerImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "provisioner-localpv" .Values.localprovisioner.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "maya-apiserverImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "m-apiserver" .Values.apiserver.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "openebs-provisionerImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "openebs-k8s-provisioner" .Values.provisioner.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "snapshot-operatorImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "snapshot-controller" .Values.snapshotOperator.controller.imageTag -}}
+{{- end -}}
+{{- end -}}
+{{- define "ndm-operatorImage" -}}
+{{- if .Values.useCustomRegistry -}}
+    {{- printf "%s/%s:%s" .Values.imageRegistry "node-disk-operator-amd64" .Values.ndmOperator.imageTag -}}
+{{- end -}}
+{{- end -}}

--- a/templates/openebs/daemonset-ndm.yaml
+++ b/templates/openebs/daemonset-ndm.yaml
@@ -34,7 +34,11 @@ spec:
       hostNetwork: true
       containers:
       - name: {{ template "openebs.name" . }}-ndm
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "ndmImage" . }}
+        {{ else }}
         image: "{{ .Values.ndm.image }}:{{ .Values.ndm.imageTag }}"
+        {{- end }} 
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true

--- a/templates/openebs/deployment-admission-server.yaml
+++ b/templates/openebs/deployment-admission-server.yaml
@@ -44,7 +44,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
         - name: admission-webhook
+          {{- if .Values.useCustomRegistry }}
+          image: {{ template "admission-webhookImage" . }}
+          {{ else }}
           image: "{{ .Values.webhook.image }}:{{ .Values.webhook.imageTag }}"
+          {{- end }}
           imagePullPolicy: Always 
           args:
             - -alsologtostderr

--- a/templates/openebs/deployment-local-provisioner.yaml
+++ b/templates/openebs/deployment-local-provisioner.yaml
@@ -34,7 +34,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-localpv-provisioner
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "localprovisionerImage" . }}
+        {{ else }}
         image: "{{ .Values.localprovisioner.image }}:{{ .Values.localprovisioner.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s

--- a/templates/openebs/deployment-maya-apiserver.yaml
+++ b/templates/openebs/deployment-maya-apiserver.yaml
@@ -35,7 +35,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-apiserver
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "maya-apiserverImage" . }}
+        {{ else }}
         image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.apiserver.ports.internalPort }}

--- a/templates/openebs/deployment-maya-provisioner.yaml
+++ b/templates/openebs/deployment-maya-provisioner.yaml
@@ -35,7 +35,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-provisioner
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "openebs-provisionerImage" . }}
+        {{ else }}
         image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s

--- a/templates/openebs/deployment-maya-snapshot-operator.yaml
+++ b/templates/openebs/deployment-maya-snapshot-operator.yaml
@@ -34,7 +34,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-snapshot-controller
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "snapshot-operatorImage" . }}
+        {{ else }}
         image: "{{ .Values.snapshotOperator.controller.image }}:{{ .Values.snapshotOperator.controller.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs snapshot controller to connect to K8s

--- a/templates/openebs/deployment-ndm-operator.yaml
+++ b/templates/openebs/deployment-ndm-operator.yaml
@@ -36,7 +36,11 @@ spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.fullname" . }}-ndm-operator
+        {{- if .Values.useCustomRegistry }}
+        image: {{ template "ndm-operatorImage" . }}
+        {{ else }}
         image: "{{ .Values.ndmOperator.image }}:{{ .Values.ndmOperator.imageTag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         readinessProbe:
           exec:


### PR DESCRIPTION
This PR will help to configure the registry for OpenEBS images. Till now the registry configuration is only possible for the images from the values.yaml by updating each image but with this PR it can be set by using 

useCustomRegistry: &sharedCustomRegistry false
imageRegistry: &sharedImageRegistry registry.mayadata.io

and users should not have to update the individual images in values.yaml while doing the Kubera installation. 
Signed-off-by: atulabhi atulabhi@gmail.com