### PR TITLE
adding namespace as an env var

### DIFF
--- a/kubera-enterprise/templates/kubera-core-configmap.yaml
+++ b/kubera-enterprise/templates/kubera-core-configmap.yaml
@@ -4,9 +4,8 @@ metadata:
   name: kubera-core-config
 data:
   CONFIGMAP_NAME: kubera-core-config
-  JWT_SECRET: cluster
   DB_SERVER: "mongodb://{{ .Release.Name }}-mongodb:27017"
-  FRONTEND_URL: "http://google.com"
+  FRONTEND_URL: "http://kubera-core-ui:9091"
   AUTH_URL: "http://localhost:3000/login"
   DB_USER: "root"
   DB_PASSWORD: "password"

--- a/kubera-enterprise/templates/kubera-core-server.yaml
+++ b/kubera-enterprise/templates/kubera-core-server.yaml
@@ -38,6 +38,10 @@ spec:
               value: "admin"
             - name: ADMIN_PASSWORD
               value: "kubera"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - containerPort: 3000
           imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR does following -

- Adds env var `POD_NAMESPACE` to identify namespace 

- Removes env `JWT_SECRET`

- Specifies the frontend service dns name to the `FRONTEND_URL` env var