### PR TITLE
Upgrading image tag of kubera to TechPreview-0

### DIFF
--- a/kubera-enterprise/values.yaml
+++ b/kubera-enterprise/values.yaml
@@ -10,7 +10,7 @@ scheme: "http"
 image:
     registry: docker.io
     organization: mayadataio
-    tag: master-ci
+    tag: TechPreview-0
 db:
     server: ""
     user: ""


### PR DESCRIPTION
Upgrading the image tag of Kubera to TechPreview-0 
Note- Release tag(TechPreview-0) of all modules has been created